### PR TITLE
fix: peer dependency version breaks npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "prepare": "npm run build"
   },
   "devDependencies": {
-    "@rsbuild/core": "^0.7.10",
+    "@rsbuild/core": "^1.0.1-beta.10",
     "@types/node": "^20.14.13",
     "prettier": "^3.3.3",
     "tsup": "^8.2.3",
     "typescript": "^5.5.4"
   },
   "peerDependencies": {
-    "@rsbuild/core": "0.x || 1.x"
+    "@rsbuild/core": "0.x || 1.x || ^1.0.1-beta.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {


### PR DESCRIPTION
https://github.com/rspack-contrib/rsbuild-plugin-image-compress/issues/3