### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "rsbuild-plugin-google-analytics",
   "version": "1.0.6",
   "repository": "https://github.com/rstackjs/rsbuild-plugin-google-analytics",
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-google-analytics#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-google-analytics/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- add the npm `homepage` field pointing to the repository README
- add the npm `bugs.url` field pointing to the GitHub issues page

## Validation
- `node -e "const pkg=require('./package.json'); if(pkg.homepage!=='https://github.com/rstackjs/rsbuild-plugin-google-analytics#readme') throw new Error('bad homepage'); if(pkg.bugs?.url!=='https://github.com/rstackjs/rsbuild-plugin-google-analytics/issues') throw new Error('bad bugs url'); console.log(JSON.stringify({name:pkg.name,homepage:pkg.homepage,bugs:pkg.bugs}, null, 2));"`
- `npm view rsbuild-plugin-google-analytics@latest name version repository homepage bugs license --json`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run lint`
- `pnpm run build`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`